### PR TITLE
Fix nightly false negative deployment.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,19 +22,3 @@ jobs:
         with:
           build-type: nightly
           github-token: ${{ secrets.GH_PAT }}
-
-      - name: Packaging
-        id: package
-        run: .\release.ps1 -Runner "${{ matrix.os }}" -Version "${{ steps.release.outputs.version}}"
-        shell: pwsh
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: output/${{ steps.package.outputs.artifact_name }}
-          asset_name: ${{ steps.package.outputs.artifact_name }}
-          asset_content_type: ${{ steps.package.outputs.content_type }}


### PR DESCRIPTION
Both `Release` and `Nightly` workflows were conflicting. With this change, `Nightly` workflow creates a version then the `Release` workflow takes the lead, packages and uploads assets properly.