### PR TITLE
works around rare serde_json issue

### DIFF
--- a/api/src/command/jobs.rs
+++ b/api/src/command/jobs.rs
@@ -78,7 +78,9 @@ impl<'a> Jobs<'a> {
         .header("Content-Type", "application/json");
 
         let resp = default_error_handler(req.send().await?).await?;
-        let result: GetJobResponse = resp.json().await?;
+        // works around serde_json issue 505
+        let data: serde_json::Value = resp.json().await?;
+        let result: GetJobResponse = serde_json::from_value(data)?;
         Ok(result.job)
     }
 


### PR DESCRIPTION
While using the esc client on a different project that had added the
tracing bunyan logger I ran into serde_json [issue 505](https://github.com/serde-rs/json/issues/505).
This commit adds a work around to the job GET code which is the only
place I've encountered any trouble so far.