### PR TITLE
adds support for GP3 disk types

### DIFF
--- a/api/src/command/clusters.rs
+++ b/api/src/command/clusters.rs
@@ -18,6 +18,10 @@ pub struct CreateClusterParams {
     pub projection_level: ProjectionLevel,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_backup_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_iops: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_throughput: Option<i32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -40,8 +44,14 @@ struct ListClustersResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct ExpandDisk {
-    disk_size_gb: usize,
+pub struct ExpandDisk {
+    pub disk_size_gb: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_iops: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_throughput: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_type: Option<String>,
 }
 
 pub struct Clusters<'a> {
@@ -169,7 +179,7 @@ impl<'a> Clusters<'a> {
         org_id: OrgId,
         project_id: ProjectId,
         cluster_id: ClusterId,
-        disk_size_gb: usize,
+        params: ExpandDisk,
     ) -> crate::Result<()> {
         let req = authenticated_request(
             &self.client,
@@ -181,7 +191,7 @@ impl<'a> Clusters<'a> {
             ),
         )
         .header("Content-Type", "application/json")
-        .json(&ExpandDisk { disk_size_gb });
+        .json(&params);
 
         let _ = default_error_handler(req.send().await?).await?;
 

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -275,6 +275,10 @@ pub struct Cluster {
     pub projection_level: ProjectionLevel,
     pub status: String,
     pub created: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_iops: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disk_throughput: Option<i32>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -823,6 +823,12 @@ struct CreateCluster {
 
     #[structopt(long, help = "Optional id of backup to restore")]
     source_backup_id: Option<String>,
+
+    #[structopt(long, help = "Optional IOPS number for disk (only AWS)")]
+    pub disk_iops: Option<i32>,
+
+    #[structopt(long, help = "Throughput in Mb/s for disk (only AWS)")]
+    pub disk_throughput: Option<i32>,
 }
 
 #[derive(Debug, StructOpt)]
@@ -888,6 +894,15 @@ struct ExpandCluster {
 
     #[structopt(long, help = "Disk size in GB")]
     disk_size_in_gb: usize,
+
+    #[structopt(long, help = "IOPS number for disk (only AWS)")]
+    disk_iops: Option<i32>,
+
+    #[structopt(long, help = "Throughput in Mb/s for disk (only AWS)")]
+    disk_throughput: Option<i32>,
+
+    #[structopt(long, help = "Optional disk type")]
+    disk_type: Option<String>,
 }
 
 #[derive(Debug, StructOpt)]
@@ -1999,6 +2014,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             server_version: params.server_version,
                             projection_level: params.projection_level,
                             source_backup_id: params.source_backup_id,
+                            disk_iops: params.disk_iops,
+                            disk_throughput: params.disk_throughput,
                         };
                         let cluster_id = client
                             .clusters(&token)
@@ -2050,7 +2067,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 params.org_id,
                                 params.project_id,
                                 params.id,
-                                params.disk_size_in_gb,
+                                esc_api::command::clusters::ExpandDisk {
+                                    disk_size_gb: params.disk_size_in_gb,
+                                    disk_iops: params.disk_iops,
+                                    disk_throughput: params.disk_throughput,
+                                    disk_type: params.disk_type,
+                                },
                             )
                             .await?;
                     }


### PR DESCRIPTION
This adds the `--disk-iops` and `--disk-throughput` options for the `create` and `expand` commands under the `mesdb clusters` subcommand, which specify additional optional properties that will be used when working with GP3 volumes in AWS.