### PR TITLE
fix: include port in API base URL and remove redundant must_use

### DIFF
--- a/base/src/errors/esc_error.rs
+++ b/base/src/errors/esc_error.rs
@@ -70,7 +70,6 @@ impl From<ApiResponseError> for EscError {
 }
 
 impl PartialEq for EscError {
-    #[must_use]
     fn eq(&self, other: &EscError) -> bool {
         match self {
             EscError::ApiResponse(err) => match other {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1988,11 +1988,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .get_current_profile()
         .and_then(|profile| {
             profile.api_base_url.as_ref().map(|url| {
-                format!(
+                let mut parsed_url = format!(
                     "{}://{}",
                     url.scheme(),
                     url.host_str().expect("Pre-validated it has a host")
-                )
+                );
+                if let Some(port) = url.port() {
+                    parsed_url.push_str(&format!(":{}", port));
+                }
+                parsed_url
             })
         })
         .unwrap_or_else(|| constants::ES_CLOUD_API_URL.to_string());


### PR DESCRIPTION
- Ensures the port number from the profile's api_base_url is preserved when constructing the client base URL, preventing connection issues when using non-standard ports
- Removes redundant #[must_use] attribute from PartialEq::eq impl as comparison results are inherently must-use by trait semantics